### PR TITLE
Fix missing routes for existing card flow

### DIFF
--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -256,6 +256,54 @@ val token = tokenManager.getToken()
                     token = token
                 )
             }
+
+            /** Additional flows for adding existing cards */
+            composable(Screen.AddExisting.route) {
+                AddExistingScreen(
+                    navController = navController,
+                    onImageSelected = { uri ->
+                        val encoded = android.net.Uri.encode(uri.toString())
+                        navController.navigate(Screen.AddImageSelect.createRoute(encoded))
+                    }
+                )
+            }
+
+            composable(
+                route = Screen.AddImageSelect.route,
+                arguments = listOf(navArgument("imageUri") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val imageUri = backStackEntry.arguments?.getString("imageUri")
+                AddImageSelectScreen(
+                    navController = navController,
+                    imageUri = imageUri
+                )
+            }
+
+            composable(
+                route = Screen.AddAutoClassify.route,
+                arguments = listOf(navArgument("imageUri") { type = NavType.StringType })
+            ) { backStackEntry ->
+                val imageUri = backStackEntry.arguments?.getString("imageUri") ?: ""
+                val bitmap = loadBitmapFromUri(context, imageUri)
+                bitmap?.let { capturedBitmap ->
+                    AddAutoClassifyScreen(
+                        navController = navController,
+                        viewModel = cardCreationViewModel,
+                        capturedImage = capturedBitmap
+                    )
+                } ?: run {
+                    LaunchedEffect(Unit) {
+                        navController.popBackStack()
+                    }
+                }
+            }
+
+            composable(Screen.AddClassified.route) {
+                AddClassifiedScreen(
+                    navController = navController,
+                    viewModel = cardCreationViewModel
+                )
+            }
     }
 }
 /*

--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -19,6 +19,8 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.example.cardify.auth.TokenManager
 import com.example.cardify.features.QuestionBank
 import com.example.cardify.models.CardCreationViewModel
@@ -27,6 +29,10 @@ import com.example.cardify.models.MainScreenViewModel
 import com.example.cardify.ui.screens.CreateEssentialsScreen
 import com.example.cardify.ui.screens.CreateProgressScreen
 import com.example.cardify.ui.screens.CreateQuestionScreen
+import com.example.cardify.ui.screens.AddExistingScreen
+import com.example.cardify.ui.screens.AddImageSelectScreen
+import com.example.cardify.ui.screens.AddAutoClassifyScreen
+import com.example.cardify.ui.screens.AddClassifiedScreen
 import com.example.cardify.ui.screens.LoginScreen
 import com.example.cardify.ui.screens.MainEmptyScreen
 import com.example.cardify.ui.screens.MainExistScreen

--- a/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
@@ -59,17 +59,6 @@ import java.util.Date
 import java.util.Locale
 import java.util.concurrent.Executors
 
-private fun createImageFile(context: Context): File {
-    val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
-    val fileName = "JPEG_${timestamp}_"
-    val storageDir = context.getExternalFilesDir(null)
-    return File.createTempFile(
-        fileName,
-        ".jpg",
-        storageDir
-    )
-}
-
 @RequiresApi(Build.VERSION_CODES.O)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
@@ -257,6 +257,12 @@ fun CameraCaptureView(
         }
     }
 }
+}
+
+
+
+
+
 
 @SuppressLint("SimpleDateFormat")
 fun createImageFile(context: Context): File {

--- a/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddFromCameraScreen.kt
@@ -51,6 +51,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.navigation.NavController
 import com.example.cardify.navigation.Screen
+import android.net.Uri
+import java.io.FileOutputStream
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -131,8 +133,9 @@ fun AddFromCameraScreen(
                         onImageCaptured = { bitmap ->
                             // Pass the bitmap to MainActivity for analysis
                             onImageCaptured(bitmap)
-                            // Navigate to auto-classify screen after capture
-                            navController.navigate(Screen.AddAutoClassify.route)
+                            val uri = saveBitmapToCache(context, bitmap)
+                            val encoded = android.net.Uri.encode(uri.toString())
+                            navController.navigate(Screen.AddAutoClassify.createRoute(encoded))
                         },
                         onError = { error ->
                             Toast.makeText(context, error, Toast.LENGTH_SHORT).show()
@@ -268,4 +271,12 @@ fun createImageFile(context: Context): File {
         ".jpg",
         storageDir
     )
-}}
+}
+
+private fun saveBitmapToCache(context: Context, bitmap: Bitmap): Uri {
+    val file = createImageFile(context)
+    FileOutputStream(file).use { out ->
+        bitmap.compress(Bitmap.CompressFormat.JPEG, 100, out)
+    }
+    return file.toUri()
+}


### PR DESCRIPTION
## Summary
- wire AddExistingScreen and related screens into AppNavigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a504b2c0832f98f7a9d9fcd34d9d