### PR TITLE
Add rule-based business card parser

### DIFF
--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -30,9 +30,14 @@ import com.example.cardify.ui.screens.CreateQuestionScreen
 import com.example.cardify.ui.screens.LoginScreen
 import com.example.cardify.ui.screens.MainEmptyScreen
 import com.example.cardify.ui.screens.MainExistScreen
+import com.example.cardify.ui.screens.AddExistingScreen
+import com.example.cardify.ui.screens.AddImageSelectScreen
 import com.example.cardify.ui.screens.RegisterCompleteScreen
 import com.example.cardify.ui.screens.RegisterScreen
 import com.example.cardify.ui.screens.SplashScreen
+import com.example.cardify.ui.screens.AddAutoClassifyScreen
+import com.example.cardify.ui.screens.AddClassifiedScreen
+import com.example.cardify.ui.screens.AddFromCameraScreen
 
 sealed class Screen(val route: String) {
     object AddAutoClassify : Screen("add_auto_classify/{imageUri}") {

--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -187,7 +188,7 @@ val token = tokenManager.getToken()
                 navController = navController,
                 onImageSelected = { uri ->
                     navController.navigate(
-                        Screen.AddImageSelect.createRoute(uri.toString())
+                        Screen.AddImageSelect.createRoute(Uri.encode(uri.toString()))
                     )
                 }
             )

--- a/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/cardify/navigation/AppNavigation.kt
@@ -177,6 +177,17 @@ val token = tokenManager.getToken()
             )
         }
 
+        composable(Screen.AddExisting.route) {
+            AddExistingScreen(
+                navController = navController,
+                onImageSelected = { uri ->
+                    navController.navigate(
+                        Screen.AddImageSelect.createRoute(uri.toString())
+                    )
+                }
+            )
+        }
+
         //CreateEssential.kt
         composable(Screen.CreateEssentials.route) {
             val tokenManager = TokenManager(LocalContext.current)

--- a/app/src/main/java/com/example/cardify/ui/screens/AddImageSelectScreen.kt
+++ b/app/src/main/java/com/example/cardify/ui/screens/AddImageSelectScreen.kt
@@ -99,7 +99,9 @@ fun AddImageSelectScreen(
             Button(
                 onClick = { 
                     decodedUri?.let { uri ->
-                        navController.navigate(Screen.AddAutoClassify.createRoute(uri))
+                        navController.navigate(
+                            Screen.AddAutoClassify.createRoute(Uri.encode(uri))
+                        )
                     } ?: run {
                         // Show error if no image is selected
                         Toast.makeText(context, "이미지를 선택해주세요.", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/example/cardify/utils/BusinessCardParser.kt
+++ b/app/src/main/java/com/example/cardify/utils/BusinessCardParser.kt
@@ -1,0 +1,49 @@
+package com.example.cardify.utils
+
+/**
+ * Simple parser to extract contact information from raw text without using NER.
+ */
+object BusinessCardParser {
+    data class ParsedCard(
+        val name: String? = null,
+        val phone: String? = null,
+        val email: String? = null,
+        val company: String? = null
+    )
+
+    private val phoneRegex = Regex("""\+?\d[\d\s-]{7,}\d""")
+    private val emailRegex = Regex("""[\w._%+-]+@[\w.-]+\.[A-Za-z]{2,}""")
+    private val companyRegex = Regex("""(Inc|Corp|LLC|Co\.|Ltd|회사|주식회사)""", RegexOption.IGNORE_CASE)
+
+    fun parse(text: String): ParsedCard {
+        var name: String? = null
+        var phone: String? = null
+        var email: String? = null
+        var company: String? = null
+
+        text.lines().forEach { line ->
+            val trimmed = line.trim()
+            if (email == null) {
+                emailRegex.find(trimmed)?.let { email = it.value }
+            }
+            if (phone == null) {
+                phoneRegex.find(trimmed)?.let { phone = it.value }
+            }
+            if (company == null && companyRegex.containsMatchIn(trimmed)) {
+                company = trimmed
+            }
+            if (name == null && trimmed.isNotEmpty() && trimmed.none { it.isDigit() }) {
+                if (trimmed.split(" ").size <= 3) {
+                    name = trimmed
+                }
+            }
+        }
+
+        return ParsedCard(
+            name = name,
+            phone = phone,
+            email = email,
+            company = company
+        )
+    }
+}

--- a/app/src/main/java/com/example/cardify/utils/BusinessCardParser.kt
+++ b/app/src/main/java/com/example/cardify/utils/BusinessCardParser.kt
@@ -8,34 +8,52 @@ object BusinessCardParser {
         val name: String? = null,
         val phone: String? = null,
         val email: String? = null,
-        val company: String? = null
+        val company: String? = null,
+        val title: String? = null,
+        val extra: String? = null
     )
 
     private val phoneRegex = Regex("""\+?\d[\d\s-]{7,}\d""")
     private val emailRegex = Regex("""[\w._%+-]+@[\w.-]+\.[A-Za-z]{2,}""")
     private val companyRegex = Regex("""(Inc|Corp|LLC|Co\.|Ltd|회사|주식회사)""", RegexOption.IGNORE_CASE)
+    private val titleKeywords = listOf(
+        "대표", "사장", "팀장", "이사", "과장", "차장", "실장", "본부장",
+        "CEO", "CTO", "COO"
+    )
 
     fun parse(text: String): ParsedCard {
         var name: String? = null
         var phone: String? = null
         var email: String? = null
         var company: String? = null
+        var title: String? = null
+        val extraLines = mutableListOf<String>()
 
         text.lines().forEach { line ->
             val trimmed = line.trim()
+            var matched = false
             if (email == null) {
-                emailRegex.find(trimmed)?.let { email = it.value }
+                emailRegex.find(trimmed)?.let { email = it.value; matched = true }
             }
-            if (phone == null) {
-                phoneRegex.find(trimmed)?.let { phone = it.value }
+            if (!matched && phone == null) {
+                phoneRegex.find(trimmed)?.let { phone = it.value; matched = true }
             }
-            if (company == null && companyRegex.containsMatchIn(trimmed)) {
+            if (!matched && company == null && companyRegex.containsMatchIn(trimmed)) {
                 company = trimmed
+                matched = true
             }
-            if (name == null && trimmed.isNotEmpty() && trimmed.none { it.isDigit() }) {
+            if (!matched && title == null && titleKeywords.any { trimmed.contains(it, ignoreCase = true) }) {
+                title = trimmed
+                matched = true
+            }
+            if (!matched && name == null && trimmed.isNotEmpty() && trimmed.none { it.isDigit() }) {
                 if (trimmed.split(" ").size <= 3) {
                     name = trimmed
+                    matched = true
                 }
+            }
+            if (!matched && trimmed.isNotEmpty()) {
+                extraLines.add(trimmed)
             }
         }
 
@@ -43,7 +61,9 @@ object BusinessCardParser {
             name = name,
             phone = phone,
             email = email,
-            company = company
+            company = company,
+            title = title,
+            extra = extraLines.joinToString("\n").takeIf { it.isNotBlank() }
         )
     }
 }

--- a/app/src/test/java/com/example/cardify/utils/BusinessCardParserTest.kt
+++ b/app/src/test/java/com/example/cardify/utils/BusinessCardParserTest.kt
@@ -1,0 +1,22 @@
+package com.example.cardify.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BusinessCardParserTest {
+    @Test
+    fun parse_basicInfo() {
+        val text = """
+            홍길동
+            주식회사 카드파이
+            +82 10-1234-5678
+            gil@example.com
+        """.trimIndent()
+
+        val parsed = BusinessCardParser.parse(text)
+        assertEquals("홍길동", parsed.name)
+        assertEquals("+82 10-1234-5678", parsed.phone)
+        assertEquals("gil@example.com", parsed.email)
+        assertEquals("주식회사 카드파이", parsed.company)
+    }
+}

--- a/app/src/test/java/com/example/cardify/utils/BusinessCardParserTest.kt
+++ b/app/src/test/java/com/example/cardify/utils/BusinessCardParserTest.kt
@@ -9,8 +9,10 @@ class BusinessCardParserTest {
         val text = """
             홍길동
             주식회사 카드파이
+            팀장
             +82 10-1234-5678
             gil@example.com
+            기타 메모
         """.trimIndent()
 
         val parsed = BusinessCardParser.parse(text)
@@ -18,5 +20,7 @@ class BusinessCardParserTest {
         assertEquals("+82 10-1234-5678", parsed.phone)
         assertEquals("gil@example.com", parsed.email)
         assertEquals("주식회사 카드파이", parsed.company)
+        assertEquals("팀장", parsed.title)
+        assertEquals("기타 메모", parsed.extra)
     }
 }


### PR DESCRIPTION
## Summary
- add a simple rule-based parser to extract business card info
- test the parser with sample Korean text

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843af1237b0832f9d702dc9064fc247